### PR TITLE
Discard ssh-agent credentials.

### DIFF
--- a/routersploit/core/ssh/ssh_client.py
+++ b/routersploit/core/ssh/ssh_client.py
@@ -49,7 +49,16 @@ class SSHCli(object):
 
         for _ in range(retries):
             try:
-                self.ssh_client.connect(self.ssh_target, self.ssh_port, timeout=SSH_TIMEOUT, banner_timeout=SSH_TIMEOUT, username=username, password=password, look_for_keys=False)
+                self.ssh_client.connect(
+                    self.ssh_target,
+                    self.ssh_port,
+                    timeout=SSH_TIMEOUT,
+                    banner_timeout=SSH_TIMEOUT,
+                    username=username,
+                    password=password,
+                    look_for_keys=False,
+                    allow_agent=False,
+                )
             except paramiko.AuthenticationException:
                 print_error(self.peer, "SSH Authentication Failed - Username: '{}' Password: '{}'".format(username, password), verbose=self.verbosity)
                 self.ssh_client.close()
@@ -82,7 +91,16 @@ class SSHCli(object):
 
         for _ in range(retries):
             try:
-                self.ssh_client.connect(self.ssh_target, self.ssh_port, timeout=SSH_TIMEOUT, banner_timeout=SSH_TIMEOUT, username=username, pkey=priv_key, look_for_keys=False)
+                self.ssh_client.connect(
+                    self.ssh_target,
+                    self.ssh_port,
+                    timeout=SSH_TIMEOUT,
+                    banner_timeout=SSH_TIMEOUT,
+                    username=username,
+                    pkey=priv_key,
+                    look_for_keys=False,
+                    allow_agent=False,
+                )
             except paramiko.AuthenticationException:
                 print_error(self.peer, "SSH Authentication Failed - Username: '{}' auth with private key".format(username), verbose=self.verbosity)
             except Exception as err:
@@ -102,7 +120,15 @@ class SSHCli(object):
         """
 
         try:
-            self.ssh_client.connect(self.ssh_target, self.ssh_port, timeout=SSH_TIMEOUT, username="root", password=random_text(12), look_for_keys=False)
+            self.ssh_client.connect(
+                self.ssh_target,
+                self.ssh_port,
+                timeout=SSH_TIMEOUT,
+                username="root",
+                password=random_text(12),
+                look_for_keys=False,
+                allow_agent=False,
+            )
         except paramiko.AuthenticationException:
             self.ssh_client.close()
             return True


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
Describe what is changed by your Pull Request. If this PR is related to the open issue (bug/feature/new module) please attach issue number.

## Verification
Provide steps to test or reproduce the PR.
 1. Start `./rsf.py`
 2. `use exploits/routers/dlink/dsl_2750b_rce`
 3. `set target 192.168.1.1`
 4. `run`
 5. ...

## Checklist
- [ ] Write module/feature 
- [ ] Write tests ([Example](https://github.com/threat9/routersploit/blob/master/tests/exploits/routers/dlink/test_dsl_2750b_rce.py))
- [ ] Document how it works ([Example](https://github.com/threat9/routersploit/blob/master/docs/modules/exploits/routers/dlink/dsl_2750b_rce.md))
